### PR TITLE
feat(responses): add response headers to results of API call methods

### DIFF
--- a/src/album/getAlbum.test.ts
+++ b/src/album/getAlbum.test.ts
@@ -31,6 +31,10 @@ test('returns an album response', async () => {
         ],
         "title": "Meme album",
       },
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -159,6 +159,7 @@ export interface ImgurApiResponse<
     | AlbumData
     | AccountData
 > {
+  headers: Record<string, string>;
   data: T;
   status: number;
   success: boolean;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -36,6 +36,7 @@ export function getImgurApiResponseFromResponse(
   response: AxiosResponse
 ): ImgurApiResponse {
   let success = true;
+  let headers: Record<string, string>;
   let data;
   let status = 200;
   const responseIsValid =
@@ -63,6 +64,7 @@ export function getImgurApiResponseFromResponse(
     success = false;
   } else if (responseIsSuccess) {
     status = response.data.status;
+    headers = response.headers;
     data = response.data.data.error
       ? response.data.data.error
       : response.data.data;
@@ -72,6 +74,7 @@ export function getImgurApiResponseFromResponse(
       response.data.data?.error?.code ??
       response.status ??
       response.data.status;
+    headers = response.headers;
     data = getResponseData(
       responseIsError
         ? response.data.errors ??
@@ -82,6 +85,7 @@ export function getImgurApiResponseFromResponse(
   }
 
   return {
+    headers,
     data,
     status,
     success,

--- a/src/gallery/getGallery.test.ts
+++ b/src/gallery/getGallery.test.ts
@@ -60,6 +60,10 @@ test('returns an image response', async () => {
           "title": "gallery-title",
         },
       ],
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/gallery/getSubredditGallery.test.ts
+++ b/src/gallery/getSubredditGallery.test.ts
@@ -62,6 +62,10 @@ test('returns a gallery response', async () => {
           "title": "gallery-title",
         },
       ],
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/gallery/searchGallery.test.ts
+++ b/src/gallery/searchGallery.test.ts
@@ -60,6 +60,10 @@ test('returns an gallery response', async () => {
           "title": "gallery-title",
         },
       ],
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/image/deleteImage.test.ts
+++ b/src/image/deleteImage.test.ts
@@ -8,6 +8,10 @@ test('delete works successfully', async () => {
   expect(response).toMatchInlineSnapshot(`
     Object {
       "data": true,
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/image/favoriteImage.test.ts
+++ b/src/image/favoriteImage.test.ts
@@ -8,6 +8,10 @@ test('favorite works successfully', async () => {
   expect(response).toMatchInlineSnapshot(`
     Object {
       "data": "favorited",
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/image/getImage.test.ts
+++ b/src/image/getImage.test.ts
@@ -12,6 +12,10 @@ test('returns an image response', async () => {
         "id": "CEddrgP",
         "title": "image-title",
       },
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }

--- a/src/image/updateImage.test.ts
+++ b/src/image/updateImage.test.ts
@@ -12,6 +12,10 @@ test('update one image with all props', async () => {
   expect(response).toMatchInlineSnapshot(`
     Object {
       "data": true,
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }
@@ -28,6 +32,10 @@ test('update one image with title only', async () => {
   expect(response).toMatchInlineSnapshot(`
     Object {
       "data": true,
+      "headers": Object {
+        "content-type": "application/json",
+        "x-powered-by": "msw",
+      },
       "status": 200,
       "success": true,
     }


### PR DESCRIPTION
fixes #185 

Response headers are now included in the result of API call methods, example:
![image](https://github.com/KenEucker/imgur/assets/11231402/8d27920e-496a-4dd8-a4c3-039ea80e57c3)