### PR TITLE
feat: Add types field to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/imgur.js",
       "require": "./dist/imgur.cjs"
     }


### PR DESCRIPTION
With that, `"module": "NodeNext"` in tsconfig.json works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package export configuration to properly expose TypeScript type definitions, improving IDE autocompletion and type safety for TypeScript consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->