### PR TITLE
Add debug step for npm identity in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,14 @@ jobs:
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
         run: npm audit signatures
+      - name: Debug npm identity
+        run: |
+          echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+          echo "GITHUB_WORKFLOW=$GITHUB_WORKFLOW"
+          echo "GITHUB_WORKFLOW_REF=$GITHUB_WORKFLOW_REF"
+          echo "GITHUB_REF=$GITHUB_REF"
+          node -p "'package=' + require('./package.json').name"
+          npm view "$(node -p "require('./package.json').name")" version --registry=https://registry.npmjs.org/
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a debug step to print npm identity information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process with additional diagnostic information during packaging and publishing.
  * Added a registry version check to help verify the published package metadata before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->